### PR TITLE
Add touchscreen interrupt (closes #1)

### DIFF
--- a/esphome/components/esp32_m5stack_core_s3/__init__.py
+++ b/esphome/components/esp32_m5stack_core_s3/__init__.py
@@ -1,14 +1,16 @@
 """M5-Stack Core S3 Component."""
 import esphome.codegen as cg
+from esphome import pins
 from esphome.components import i2c
+from esphome.components import touchscreen
 import esphome.config_validation as cv
 
-from esphome.const import CONF_ID
+from esphome.const import CONF_ID, CONF_INTERRUPT_PIN
 
 from ..aw9523 import AW9523Component
 
 CODEOWNERS = ["@gnumpi"]
-DEPENDENCIES = ["i2c", "aw9523"]
+DEPENDENCIES = ["i2c", "aw9523", "touchscreen"]
 
 m5stack_ns = cg.esphome_ns.namespace("m5stack")
 M5StackCoreS3 = m5stack_ns.class_("M5StackCoreS3", i2c.I2CDevice, cg.Component)
@@ -16,6 +18,7 @@ M5StackCoreS3 = m5stack_ns.class_("M5StackCoreS3", i2c.I2CDevice, cg.Component)
 CONF_AW9523 = "aw9523"
 CONF_USB_OTG_EN = "usb_otg_en"
 CONF_BUS_OUT_EN = "bus_out_en"
+CONF_TOUCHSCREEN = "touchscreen"
 
 CONFIG_SCHEMA = cv.Schema(
     {
@@ -23,6 +26,10 @@ CONFIG_SCHEMA = cv.Schema(
         cv.Optional(CONF_AW9523): cv.use_id(AW9523Component),
         cv.Optional(CONF_USB_OTG_EN, default=False): cv.boolean,
         cv.Optional(CONF_BUS_OUT_EN, default=False): cv.boolean,
+        cv.Optional(CONF_INTERRUPT_PIN): cv.All(
+            pins.internal_gpio_input_pin_schema
+        ),
+        cv.Optional(CONF_TOUCHSCREEN): cv.use_id(touchscreen.Touchscreen),
     }
 ).extend(i2c.i2c_device_schema(0x36))
 
@@ -36,3 +43,9 @@ async def to_code(config):
         cg.add(var.set_aw9523(aw9523))
         cg.add(var.set_usb_otg_en(config[CONF_USB_OTG_EN]))
         cg.add(var.set_bus_out_en(config[CONF_BUS_OUT_EN]))
+    if CONF_INTERRUPT_PIN in config:
+        interrupt_pin = await cg.gpio_pin_expression(config[CONF_INTERRUPT_PIN])
+        cg.add(var.set_interrupt_pin(interrupt_pin))
+    if CONF_TOUCHSCREEN in config:
+        touchscreen = await cg.get_variable(config[CONF_TOUCHSCREEN])
+        cg.add(var.set_touchscreen(touchscreen))

--- a/esphome/components/esp32_m5stack_core_s3/m5stack_core_s3.h
+++ b/esphome/components/esp32_m5stack_core_s3/m5stack_core_s3.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "esphome/components/i2c/i2c.h"
+#include "esphome/components/touchscreen/touchscreen.h"
 #include "esphome/core/component.h"
 
 #include "../aw9523/aw9523.h"
@@ -9,9 +10,17 @@ namespace m5stack {
 
 class AXP2101Component;
 
+struct M5StackCoreS3Store {
+  ISRInternalGPIOPin interrupt_pin_;
+  bool trigger_;
+
+  static void aw9523_intr(M5StackCoreS3Store *arg);
+};
+
 class M5StackCoreS3 : public i2c::I2CDevice, public Component {
 public:
     void setup() override;
+    void loop() override;
     void dump_config() override {};
     float get_setup_priority() const override { return setup_priority::DATA; };
 
@@ -26,9 +35,15 @@ public:
     void set_usb_otg_en(bool flag){this->usb_otg_en_ = flag;}
     void set_bus_out_en(bool flag){this->bus_out_en_ = flag;}
 
+    void set_interrupt_pin(InternalGPIOPin *pin) { this->interrupt_pin_ = pin; }
+    void set_touchscreen(touchscreen::Touchscreen *touchscreen) { touchscreen_ = touchscreen; }
+
 protected:
+    M5StackCoreS3Store store_{};
     AXP2101Component* axp2101_{nullptr};
     aw9523::AW9523Component* aw9523_{nullptr};
+    InternalGPIOPin *interrupt_pin_{nullptr};
+    touchscreen::Touchscreen *touchscreen_{nullptr};
 
     bool usb_otg_en_{false};
     bool bus_out_en_{false};


### PR DESCRIPTION
This is a work in progress, as it requires some modifications upstream to trigger the touchscreen interrupt programmatically. It is working though!

Added functions to `touchscreen.cpp` (and `touchscreen.h` respectively):
```cpp
void Touchscreen::trigger_external_interrupt() { this->store_.touched = true; }

void Touchscreen::setup_external_interrupt() {
  this->store_.init = true;
  this->store_.touched = false;
}
```

Config example:
```yaml
touchscreen:
  - platform: ft63x6
    id: m5cores3_touch

esp32_m5stack_core_s3:
  interrupt_pin: GPIO21
  touchscreen: m5cores3_touch
```